### PR TITLE
Run when pressing Alt+Enter

### DIFF
--- a/demos/Turtle/Turtle.fs
+++ b/demos/Turtle/Turtle.fs
@@ -153,6 +153,7 @@ let view model dispatch =
                         Textarea.Props [
                             Value model.Input
                             OnChange (fun e -> e.Value |> SetInput |> dispatch )
+                            OnKeyDown (fun e -> if e.key = "Enter" && e.altKey then model.Input |> Run |> dispatch)
                             Style [Height 500]
                         ] ] []
 


### PR DESCRIPTION
It'd be nice to have a shortcut for quickly running the instructions without having to use the mouse/touchpad to go to the Run button. I just edited this directly in Github, so I have no idea if it works 😅 